### PR TITLE
Create a Table of Contents for all Gruntwork code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Each Gruntwork Infrastructure Package exists in a single, private GitHub repo, w
 
 All packages include access to [package-terraform-utilities](https://github.com/gruntwork-io/package-terraform-utilities).
 
+All packages are validated using our automated testing tool, [terratest](https://github.com/gruntwork-io/terratest).
+
 ### Open Source Infrastructure Packages
 
 In the near future, we will be releasing open source Infrastructure Packages that configure best-practices implementations


### PR DESCRIPTION
A customer recently purchased access to our "Unlimited" offering and I was tired of manually assembling the list of Packages to which to grant them access. 

In the end, this Table of Contents is meant to solve two problems:

1. Make it easier for Gruntwork to setup new customers with GitHub repo access.
2. Provide Gruntwork customers with a simple, authoritative reference of everything we've done.

'cc @brikis98 @mcalhoun 