### PR TITLE
Docs site support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+generated

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -33,4 +33,4 @@ function build_for_docssite {
 
 }
 
-build_for_docssite ./generated/introduction/library-catalog/index.md
+build_for_docssite ./generated/library-catalog/index.md

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -18,10 +18,11 @@ function replace_header {
   local -r frontmatter='---\
 title: "Gruntwork IaC Library Catalog"\
 date: __DATE__\
+origin: https://github.com/gruntwork-io/toc/blob/master/README.md
 tags: ["terraform"]\
 ---'
 
-  sed -i'' -e "1 s/^.*$/$frontmatter/g" "$infile"
+  sed -i'' -e "1 s|^.*$|$frontmatter|g" "$infile"
   sed -i'' -e "s/__DATE__/$(get_last_commit_date)/g" "$infile"
 }
 

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# This script prepares the README for use in the docs site. The main thing it does is remove the title and replace it
+# with a frontmatter.
+#
+
+function create_artifact {
+  local -r target_file="$1"
+  local -r target_dir="$(dirname $target_file)"
+
+  mkdir -p "$target_dir"
+  cp ./README.md "$target_file"
+}
+
+function replace_header {
+  local -r infile="$1"
+
+  local -r frontmatter='---\
+title: "Gruntwork IaC Library Catalog"\
+date: __DATE__\
+tags: ["terraform"]\
+---'
+
+  sed -i'' -e "1 s/^.*$/$frontmatter/g" "$infile"
+  sed -i'' -e "s/__DATE__/$(date +%Y-%m-%d)/g" "$infile"
+}
+
+function build_for_docssite {
+  local -r target_file="$1"
+
+  create_artifact "$target_file"
+  replace_header "$target_file"
+
+}
+
+build_for_docssite ./generated/introduction/library-catalog/index.md

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -31,7 +31,7 @@ function clean_outfolder {
   local -r abs_target_dir="$(realpath $target_dir)"
 
   # Remove anything that is not markdown
-  find "$abs_target_dir" -not -name "*.md" -delete
+  find "$abs_target_dir" -type f -not -name "*.md" -delete
 }
 
 function build_for_docssite {

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -25,12 +25,21 @@ tags: ["terraform"]\
   sed -i'' -e "s/__DATE__/$(date +%Y-%m-%d)/g" "$infile"
 }
 
+function clean_outfolder {
+  local -r target_file="$1"
+  local -r target_dir="$(dirname $target_file)"
+  local -r abs_target_dir="$(realpath $target_dir)"
+
+  # Remove anything that is not markdown
+  find "$abs_target_dir" -not -name "*.md" -delete
+}
+
 function build_for_docssite {
   local -r target_file="$1"
 
   create_artifact "$target_file"
   replace_header "$target_file"
-
+  clean_outfolder "$target_file"
 }
 
-build_for_docssite ./generated/library-catalog/index.md
+build_for_docssite ./generated/introduction/library-catalog/index.md

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -18,7 +18,7 @@ function replace_header {
   local -r frontmatter='---\
 title: "Gruntwork IaC Library Catalog"\
 date: __DATE__\
-origin: https:\/\/github.com/gruntwork-io/toc/blob/master/README.md
+origin: "https:\/\/github.com\/gruntwork-io\/toc\/blob\/master\/README.md"\
 tags: ["terraform"]\
 ---'
 

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -18,11 +18,11 @@ function replace_header {
   local -r frontmatter='---\
 title: "Gruntwork IaC Library Catalog"\
 date: __DATE__\
-origin: https://github.com/gruntwork-io/toc/blob/master/README.md
+origin: https:\/\/github.com/gruntwork-io/toc/blob/master/README.md
 tags: ["terraform"]\
 ---'
 
-  sed -i'' -e "1 s|^.*$|$frontmatter|g" "$infile"
+  sed -i'' -e "1 s/^.*$/$frontmatter/g" "$infile"
   sed -i'' -e "s/__DATE__/$(get_last_commit_date)/g" "$infile"
 }
 

--- a/build_for_docssite.sh
+++ b/build_for_docssite.sh
@@ -22,7 +22,13 @@ tags: ["terraform"]\
 ---'
 
   sed -i'' -e "1 s/^.*$/$frontmatter/g" "$infile"
-  sed -i'' -e "s/__DATE__/$(date +%Y-%m-%d)/g" "$infile"
+  sed -i'' -e "s/__DATE__/$(get_last_commit_date)/g" "$infile"
+}
+
+function get_last_commit_date {
+  # We use python to get the date of the last commit in the format YYYY-MM-DD. This works by getting the timestamp of
+  # the last commit using `git log -1`, and then converting to the desired output format.
+  python -c "import time; print(time.strftime('%Y-%m-%d', time.localtime($(git log -1 --format="%at"))))"
 }
 
 function clean_outfolder {

--- a/gruntydocs.yml
+++ b/gruntydocs.yml
@@ -1,0 +1,5 @@
+# What command to run to generate the docs.
+builder: ./build_for_docssite.sh
+# Where the target files live. These will be pulled in verbatim to /content in the docs repo.
+targets:
+  - ./generated


### PR DESCRIPTION
This sets up the `doc-sourcer` pipeline for this repo so that the README can be read into the docs site. Please be advised that some of the verbiage may not be compatible (e.g the first sentence of the README states `this repo`).