### PR TITLE
Remove private beta notation on Kubernetes repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Our IaC modules that support deploying and managing production grade infrastruct
     1. [run-filebeat](https://github.com/gruntwork-io/package-elk/tree/master/modules/run-filebeat): Runs Filebeat on an application server to ship application logs off to Logstash cluster.
     1. [run-collectd](https://github.com/gruntwork-io/package-elk/tree/master/modules/run-collectd): Runs CollectD on an application server and ships off machine metrics to th Logstash cluster.
 
-1. **Kubernetes**: _(The packages in this category are in private beta)_ Deploy and manage a best practice Kubernetes cluster and Kubernetes services.
+1. **Kubernetes**: Deploy and manage a best practice Kubernetes cluster and Kubernetes services.
     1. **[EKS](https://github.com/gruntwork-io/terraform-aws-eks)**: Deploy and manage a best practice EKS cluster. The main modules are:
         1. [eks-cluster-control-plane](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-control-plane): Deploy an EKS control plane managed by AWS with support to configure your local `kubectl` to authenticate with EKS.
         1. [eks-cluster-workers](https://github.com/gruntwork-io/terraform-aws-eks/tree/master/modules/eks-cluster-workers): Deploy a cluster of EC2 instances registered as Kubernetes workers with auto-recovery of failed nodes.


### PR DESCRIPTION
We are now ready to mark these repos as GA now that we reached the reference architecture integration milestone.