### PR TITLE
Update deprecated README links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,10 @@
 
 **THIS REPO IS NOW DEPRECATED**
 
-Please use the [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) page to browse all Gruntwork code. For more information, see [How to use the Gruntwork Infrastructure as Code Library
+Instead, please visit:
+
+- [Gruntwork Infrastructure as Code Library](https://gruntwork.io/infrastructure-as-code-library/) for a high-level overview of our Infrastructure as Code Library.
+- [Gruntwork Repo Browser](https://gruntwork.io/repos) to browse the repos in the Gruntwork Infrastructure as Code Library. 
+
+For more information, see [How to use the Gruntwork Infrastructure as Code Library
 ](https://gruntwork.io/guides/foundations/how-to-use-gruntwork-infrastructure-as-code-library/).


### PR DESCRIPTION
I wanted to make sure we get the repo browser in there since that's not currently linked from the IaC Library page, though we plan to add that soon.